### PR TITLE
admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!, except: [:index]
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :check_admin, if: :current_user
   def configure_permitted_parameters
     added_attrs = [:email, :name]
     devise_parameter_sanitizer.permit(:sign_in, keys: added_attrs)
@@ -12,4 +13,14 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource)
     chat_rooms_path
   end
+  private
+    def check_admin
+      if "/users".include?(request.path)
+        name = "admin"
+        passwd = "b51c4e17219231dc715bb26a79f040a411e60bf0"
+        authenticate_or_request_with_http_basic('AdminChecker') do |n, p|
+          n == name && Digest::SHA1.hexdigest(p) == passwd
+        end
+      end
+    end
 end


### PR DESCRIPTION
I added a function of checking the administrator's account.
When you clicked the button "User List" or typed "http://localhost:3000/users" or anything else to move to the user list, you will be asked to input the name and password as an administrator.
Once you successfully accessed to the page, you will never be asked until you closed the web browser.